### PR TITLE
Set second flag independently of the second interrupt

### DIFF
--- a/hw/timer/stm32_rtc.c
+++ b/hw/timer/stm32_rtc.c
@@ -144,9 +144,8 @@ static void stm32_rtc_tick(void *opaque)
     s->RTC_CNT[0]=new_CNT & 0xffff;
     s->RTC_CNT[1]=new_CNT >> 16;
 
-    /* set seconde flag eachche cycle of f_TR_CLK if
-       seconde interupt is enabled */
-    if(s->RTC_CR[1] & (1<<RTC_CRH_SECIE_BIT)){
+    /* set second flag each cycle of f_TR_CLK */
+    if(s->RTC_CR[1]){
     s->RTC_CR[0]|=(1 << RTC_CRL_SECF_BIT); 
     }
      


### PR DESCRIPTION
From RM008 page 485, SECF is asserted on each RTC Core clock cycle. This is important for the correct setup of the Alarm interrupt and is the default hardware behaviour.